### PR TITLE
Migrate to artifact publish token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -32,11 +35,15 @@ jobs:
       with:
         name: test-reports
         path: build/reports/tests
+    - name: Get publish token
+      id: publish-token
+      if: github.event.inputs.release == 'yes'
+      uses: atlassian-labs/artifact-publish-token@v1.0.1
     - name: Release
       if: github.event.inputs.release == 'yes'
       env:
-        atlassian_private_username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        atlassian_private_password: ${{ secrets.ARTIFACTORY_API_KEY }}
+        atlassian_private_username: ${{ steps.publish-token.outputs.artifactoryUsername }}
+        atlassian_private_password: ${{ steps.publish-token.outputs.artifactoryApiKey }}
       run: |
         ./gradlew release -Prelease.customUsername=${{ secrets.REPOSITORY_ACCESS_TOKEN }}
         ./gradlew publish


### PR DESCRIPTION

Artifactory secrets are being deprecated.

Please review and merge this change to use the new artifact publish token.