### PR TITLE
JPERF-570: Remove log4j dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/ssh-ubuntu/compare/release-0.3.0...master
 
+### Fixed
+- Remove all `log4j` dependencies from POM. Fix [JPERF-570].
+
+[JPERF-570]: https://ecosystem.atlassian.net/browse/JPERF-570
+
 ## [0.3.0] - 2022-11-07
 [0.3.0]: https://github.com/atlassian/ssh-ubuntu/compare/release-0.2.6...release-0.3.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 val kotlinVersion = "1.2.70"
-val log4jVersion = "2.17.1"
 
 plugins {
     kotlin("jvm").version("1.2.70")
@@ -15,12 +14,12 @@ configurations.all {
         eachDependency {
             when (requested.module.toString()) {
                 "org.jetbrains:annotations" -> useVersion("13.0")
-                "org.slf4j:slf4j-api" -> useVersion("1.7.25")
+                // conflict between testcontainers, docker-java and sshj
+                "org.slf4j:slf4j-api" -> useVersion("1.7.36")
                 "net.java.dev.jna:jna" -> useVersion("5.5.0")
             }
             when (requested.group) {
                 "org.jetbrains.kotlin" -> useVersion(kotlinVersion)
-                "org.apache.logging.log4j" -> useVersion(log4jVersion)
             }
         }
     }
@@ -30,19 +29,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     api("com.atlassian.performance.tools:ssh:[2.0.0,3.0.0)")
     api("org.testcontainers:testcontainers:1.17.3")
-    log4j(
-        "api",
-        "core",
-        "slf4j-impl"
-    ).forEach { implementation(it) }
     testCompile("junit:junit:4.13.+")
     testCompile("org.assertj:assertj-core:3.11.1")
-}
-
-fun log4j(
-    vararg modules: String
-): List<String> = modules.map { module ->
-    "org.apache.logging.log4j:log4j-$module:$log4jVersion"
 }
 
 tasks.getByName("wrapper", Wrapper::class).apply {

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -27,5 +27,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -27,5 +27,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -27,5 +27,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3

--- a/gradle/dependency-locks/dockerJava.lockfile
+++ b/gradle/dependency-locks/dockerJava.lockfile
@@ -3,5 +3,5 @@
 # This file is expected to be part of source control.
 com.aries:docker-java-shaded:3.1.0-rc-7
 javax.activation:activation:1.1.1
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.slf4j:slf4j-simple:1.7.5

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -27,5 +27,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -27,5 +27,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -28,5 +28,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -28,5 +28,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh:2.4.3
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.13
@@ -28,5 +28,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
 org.rnorth.duct-tape:duct-tape:1.0.8
-org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-api:1.7.36
 org.testcontainers:testcontainers:1.17.3


### PR DESCRIPTION
They're not used in `src/main` or `src/test`.